### PR TITLE
Check that data file is not empty before populating

### DIFF
--- a/lib/locomotive/mounter/reader/file_system/content_entries_reader.rb
+++ b/lib/locomotive/mounter/reader/file_system/content_entries_reader.rb
@@ -27,7 +27,7 @@ module Locomotive
 
               attributes.each_with_index do |_attributes, index|
                 self.add(content_type, _attributes, index)
-              end
+              end unless attributes == false
             end
           end
 


### PR DESCRIPTION
When there are no records in data file for a model (just in case you don't need any), it will throw an error

Refers to Issue at wagon repository: http://github.com/locomotivecms/wagon/issues/184
