### PR TITLE
Fix Api::ThemeAssetReader to handle protocol-relative urls.

### DIFF
--- a/lib/locomotive/mounter/reader/api/theme_assets_reader.rb
+++ b/lib/locomotive/mounter/reader/api/theme_assets_reader.rb
@@ -19,6 +19,7 @@ module Locomotive
 
             self.items = self.get(:theme_assets).map do |attributes|
               url = attributes.delete('url')
+              url.gsub!(/^\/\//, "https://")
 
               attributes['uri'] = URI(url =~ /^https?:\/\// ? url : "#{self.base_uri_with_scheme}#{url}")
 


### PR DESCRIPTION
We have a protocol-relative AWS CloudFront url specified as our asset host ("//xxxxxxxxxxx.cloudfront.net"). This change is needed to make Mounter/Wagon work.
