### PR TITLE
add support for bower

### DIFF
--- a/lib/locomotive/mounter/extensions/sprockets.rb
+++ b/lib/locomotive/mounter/extensions/sprockets.rb
@@ -1,4 +1,5 @@
 require 'yui/compressor'
+require 'json'
 
 module Locomotive
   module Mounter
@@ -25,6 +26,14 @@ module Locomotive
 
             %w(fonts stylesheets javascripts).each do |name|
               env.append_path File.join(site_path, 'public', name)
+            end
+            bower_file_path = "#{site_path}/.bowerrc"
+
+            if File.exist?(bower_file_path)
+              bower_config = JSON.parse(IO.read("#{site_path}/.bowerrc"))
+              bower_folder = bower_config["directory"]
+
+              env.append_path File.join(site_path, bower_folder) if bower_folder
             end
           end
         end


### PR DESCRIPTION
regarding PR #30 I might be more confortable using bower to manage the assets instead of a third party. 

With this PR, you just need to get this in the root of your app: 

``` json
{
  "directory": "public/vendor/"
}
```

then you add your front end assets in bower.json like you'd in your Gemfile:

``` json
{
  "name": "project",
  "version": "0.0.1",
  "private": "true",
  "dependencies": {
    "jquery": "~> 1.11.0",
    "bootstrap": "3.1.1",
    "font-awesome": "4.0.3",
    "modernizr": "git@github.com:Modernizr/Modernizr.git",
  }
}

```

then `bower install`will install all the libs with dependencies and sources etc in public/vendor.

You can now require them in your scss:

``` scss
@import 'bootstrap';
```

and js:

``` js
//= require 'bootstrap'
```

How do you guys like it? @did @jaredklewis 
