### PR TITLE
Preordered the Content Types

### DIFF
--- a/lib/locomotive/mounter/writer/api/content_entries_writer.rb
+++ b/lib/locomotive/mounter/writer/api/content_entries_writer.rb
@@ -39,8 +39,60 @@ module Locomotive
 
             self.each_locale do |locale|
               self.output_locale
+              print "=====Preorder=======\n"
 
+              content_types_sorted = {}
+              dependencies = {}
               self.content_types.each do |slug, content_type|
+                print "--[#{slug}]--\n"
+                if content_type.with_relationships?
+                  content_type.fields.each do |field|
+                    next unless field.is_relationship? || field.type == :has_many
+                    if field.type == :belongs_to
+                      dependencies[slug] ? dependencies[slug] << field.class_name : dependencies[slug] = [field.class_name]
+                    else
+                      content_types_sorted[slug] = content_types[slug]
+                    end
+                    print "    field #{field.class_name}"
+                    print "      type: #{field.type.to_s}\n"
+                  end
+                else
+                  content_types_sorted[slug] = content_types[slug]
+                end
+              end
+
+              print "#{dependencies}\n"
+
+              while !dependencies.empty?
+                print "Sorted content_types: \n"
+                content_types_sorted.each do |slug, content_type|
+                  print '  ' + content_type.name + "\n"
+                end
+
+                print "#{dependencies}\n"
+
+                dependencies.each do |dependant, depends|
+                  dependencies[dependant] = depends.select do |dependency|
+                    !content_types_sorted[dependency]
+                  end
+                  if depends.empty?
+                    dependencies.delete(dependant)
+                    content_types_sorted[dependant] = content_types[dependant]
+                  end
+                end
+              end
+
+              print "Sorted content_types: \n"
+
+
+
+              content_types_sorted.values.each do |content_type|
+                print '  ' + content_type.name + "\n"
+              end
+
+              print "=====Preorder=======\n"
+
+              content_types_sorted.each do |slug, content_type|
                 (content_type.entries || []).each do |entry|
                   next unless entry.translated_in?(locale)
 

--- a/lib/locomotive/mounter/writer/api/content_entries_writer.rb
+++ b/lib/locomotive/mounter/writer/api/content_entries_writer.rb
@@ -225,7 +225,7 @@ module Locomotive
             params = entry.to_params
 
             entry.each_dynamic_field do |field, value|
-              unless field.is_relationship?
+              #unless field.is_relationship?
                 case field.type.to_sym
                 when :string, :text
                   params[field.name] = self.replace_content_assets!(value)
@@ -239,7 +239,7 @@ module Locomotive
                 else
                   params[field.name] = value
                 end
-              end
+              #end
             end
 
             params


### PR DESCRIPTION
so when you push, you push in the corre…ct order, that is if a content_type_entry depends on others, the others are loaded first, might not be 100% working related to issue https://github.com/locomotivecms/engine/issues/972#issuecomment-121882361